### PR TITLE
If failover target replica has a metrics sidecar, failover will fail.

### DIFF
--- a/util/failover.go
+++ b/util/failover.go
@@ -86,7 +86,7 @@ func GetPod(clientset *kubernetes.Clientset, deploymentName, namespace string) (
 	for _, v := range pods.Items {
 		pod = &v
 	}
-	if len(pod.Spec.Containers) < 1 {
+	if len(pod.Spec.Containers) != 1 && pod.Labels["crunchy_collect"] == "false" {
 		return pod, errors.New("could not find a container in the pod")
 	}
 

--- a/util/failover.go
+++ b/util/failover.go
@@ -86,7 +86,7 @@ func GetPod(clientset *kubernetes.Clientset, deploymentName, namespace string) (
 	for _, v := range pods.Items {
 		pod = &v
 	}
-	if len(pod.Spec.Containers) != 1 {
+	if len(pod.Spec.Containers) < 1 {
 		return pod, errors.New("could not find a container in the pod")
 	}
 


### PR DESCRIPTION
If failover target has any number of containers other than 1 in the pod, the failover will fail.
This means that if a replica has a metrics sidecar (therefore 2 containers in the pod) and is the target of a failover, the failover will fail.

To fix this I altered the check to accommodate this.